### PR TITLE
Implement SQLite output storage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -84,14 +84,13 @@ builder.Services.AddTransient((serviceProvider) =>
     return new Kernel(serviceProvider);
 });
 
-builder.Services.AddScoped<IAgentOutput, FileAgentOutput>(serviceProvider =>
-{
-    // Use a directory in the current working directory for output files
-    var outputDirectory = Path.Combine(Directory.GetCurrentDirectory(), "agent-output");
-    Directory.CreateDirectory(outputDirectory);
-    var logger = serviceProvider.GetRequiredService<ILogger<FileAgentOutput>>();
-    return new FileAgentOutput(logger, outputDirectory);
-});
+// Configure agent output to use SQLite database
+var outputDbPath = builder.Configuration["OutputDb:Path"] ?? "agent-output.db";
+var connectionString = Environment.GetEnvironmentVariable("OUTPUT_DB_CONNECTION_STRING")
+    ?? $"Data Source={Path.Combine(Directory.GetCurrentDirectory(), outputDbPath)}";
+
+builder.Services.AddSingleton(new DbOutputOptions { ConnectionString = connectionString });
+builder.Services.AddScoped<IAgentOutput, DbAgentOutput>();
 
 var username = Environment.GetEnvironmentVariable("FASTMAIL_USERNAME");
 var password = Environment.GetEnvironmentVariable("FASTMAIL_APP_PASSWORD");

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Sleepr
+
+## SQLite Output Store
+
+Sleepr stores agent output using an SQLite database. The default database file
+location is configured in `appsettings.json` under `OutputDb:Path`.
+
+Set the connection string in a `.env` file before running the application:
+
+```
+OUTPUT_DB_CONNECTION_STRING=Data Source=data/agent-output.db
+```
+
+Create the `.env` file at the repository root (it is ignored by Git).

--- a/Services/DbAgentOutput.cs
+++ b/Services/DbAgentOutput.cs
@@ -1,0 +1,42 @@
+using Microsoft.Data.Sqlite;
+using Sleepr.Interfaces;
+
+namespace Sleepr.Services;
+
+public class DbAgentOutput : IAgentOutput
+{
+    private readonly ILogger<DbAgentOutput> _logger;
+    private readonly DbOutputOptions _options;
+
+    public DbAgentOutput(ILogger<DbAgentOutput> logger, DbOutputOptions options)
+    {
+        _logger = logger;
+        _options = options;
+    }
+
+    public async Task<string> SaveAsync(string content)
+    {
+        using var connection = new SqliteConnection(_options.ConnectionString);
+        await connection.OpenAsync();
+
+        var createCmd = connection.CreateCommand();
+        createCmd.CommandText = @"CREATE TABLE IF NOT EXISTS AgentOutputs (
+            Id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Content TEXT NOT NULL,
+            CreatedAt TEXT NOT NULL
+        );";
+        await createCmd.ExecuteNonQueryAsync();
+
+        var insertCmd = connection.CreateCommand();
+        insertCmd.CommandText = "INSERT INTO AgentOutputs (Content, CreatedAt) VALUES ($content, $createdAt);";
+        insertCmd.Parameters.AddWithValue("$content", content);
+        insertCmd.Parameters.AddWithValue("$createdAt", DateTime.UtcNow.ToString("o"));
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var idCmd = connection.CreateCommand();
+        idCmd.CommandText = "SELECT last_insert_rowid();";
+        var id = (long)(await idCmd.ExecuteScalarAsync() ?? 0L);
+        _logger.LogInformation("Saved agent output to DB with id {Id}", id);
+        return id.ToString();
+    }
+}

--- a/Services/DbOutputOptions.cs
+++ b/Services/DbOutputOptions.cs
@@ -1,0 +1,6 @@
+namespace Sleepr.Services;
+
+public class DbOutputOptions
+{
+    public string ConnectionString { get; set; } = string.Empty;
+}

--- a/Sleepr.csproj
+++ b/Sleepr.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="MailKit" Version="4.12.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.56.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.56.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAIInference" Version="1.56.0-beta" />

--- a/appsettings.json
+++ b/appsettings.json
@@ -28,6 +28,9 @@
         }
       }
     ]
+  },
+  "OutputDb": {
+    "Path": "data/agent-output.db"
   }
 }
 


### PR DESCRIPTION
## Summary
- add `DbAgentOutput` that saves chat results to an SQLite database
- register the database output via new `DbOutputOptions`
- store database location in `appsettings.json`
- document connection string environment variable in `README`
- add required `Microsoft.Data.Sqlite` package

## Testing
- `dotnet build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6860168a768c8328b7296cc22f4c01b8