### PR TITLE
Add agent pipeline refactor roadmap

### DIFF
--- a/PIPELINE_API.md
+++ b/PIPELINE_API.md
@@ -1,0 +1,143 @@
+# Agent Pipeline API Guide
+
+This document describes the proposed fluent API for composing and executing agent pipelines after the refactor. The API focuses on flexibility and minimal boilerplate while maintaining the ability to restrict available plugins.
+
+## Core Interfaces
+
+```csharp
+// Carries request data, cloned kernel and any intermediate state
+public class PipelineContext
+{
+    public List<AgentRequestItem> RequestHistory { get; }
+    public Kernel Kernel { get; set; }
+    public McpPluginManager PluginManager { get; }
+    public IList<string> SelectedPlugins { get; set; } = new List<string>();
+    public string? FinalResult { get; set; }
+    // other fields as needed
+
+    public PipelineContext(List<AgentRequestItem> history,
+                           Kernel kernel,
+                           McpPluginManager pluginManager)
+    {
+        RequestHistory = history;
+        Kernel = kernel;
+        PluginManager = pluginManager;
+    }
+}
+
+public interface IAgentPipelineStep
+{
+    Task ExecuteAsync(PipelineContext context);
+}
+
+public interface IAgentPipeline
+{
+    Task RunAsync(PipelineContext context);
+}
+
+public interface IAgentPipelineBuilder
+{
+    IAgentPipelineBuilder Use(IAgentPipelineStep step);
+    IAgentPipeline Build();
+}
+```
+
+## Building a Pipeline
+
+Steps are registered in the order they should run. The builder returns an `IAgentPipeline` that can be executed with a `PipelineContext`.
+
+```csharp
+var pipeline = new AgentPipelineBuilder()
+    .Use(new LoadChatHistoryStep())
+    .Use(new SelectPluginsStep(orchestratorPath: "orchestrator"))
+    .Use(new LoadPluginsStep())
+    .Use(new RunTaskAgentStep("task-runner"))
+    .Use(new SaveOutputStep())
+    .Build();
+
+var context = new PipelineContext(req.History, kernel, pluginManager);
+await pipeline.RunAsync(context);
+string? response = context.FinalResult;
+```
+
+### Extension Methods
+
+Common sequences can be exposed via extension methods on `IAgentPipelineBuilder` so controllers stay concise:
+
+```csharp
+public static class StandardPipelineExtensions
+{
+    public static IAgentPipelineBuilder UseDefaultHistory(this IAgentPipelineBuilder builder)
+        => builder.Use(new LoadChatHistoryStep());
+
+    public static IAgentPipelineBuilder UseOrchestrator(this IAgentPipelineBuilder builder, string path = "orchestrator")
+        => builder.Use(new SelectPluginsStep(path));
+
+    public static IAgentPipelineBuilder UseTaskRunner(this IAgentPipelineBuilder builder, string path = "task-runner")
+        => builder.Use(new RunTaskAgentStep(path));
+}
+```
+
+Controllers can then compose a pipeline using these helpers:
+
+```csharp
+var pipeline = pipelineBuilder
+    .UseDefaultHistory()
+    .UseOrchestrator()
+    .Use(new LoadPluginsStep())
+    .UseTaskRunner()
+    .Use(new SaveOutputStep())
+    .Build();
+
+await pipeline.RunAsync(new PipelineContext(req.History, kernel, pluginManager));
+```
+
+## Loading Plugins
+
+`LoadPluginsStep` is responsible for cloning the kernel and injecting only the requested plugins:
+
+```csharp
+public class LoadPluginsStep : IAgentPipelineStep
+{
+    public async Task ExecuteAsync(PipelineContext context)
+    {
+        var clone = context.Kernel.Clone();
+        foreach (var pluginName in context.SelectedPlugins)
+        {
+            var manifest = context.PluginManager.GetManifestByName(pluginName);
+            var client = await context.PluginManager.AcquireClientAsync(manifest.Id);
+            var tools = await client.ListToolsAsync();
+            clone.Plugins.AddFromFunctions(manifest.Id, tools.Select(t => t.AsKernelFunction()));
+        }
+        context.Kernel = clone;
+    }
+}
+```
+
+This keeps the plugin subset behaviour intact and isolates it from the rest of the pipeline.
+
+## Running from Controllers
+
+Controllers obtain an `IAgentPipelineBuilder` and configure the pipeline per request.
+
+```csharp
+[HttpPost("run-task")]
+public async Task<ActionResult<AgentResponse>> RunTask([FromBody] AgentRequest req)
+{
+    var context = new PipelineContext(req.History, _kernel, _pluginManager);
+    var pipeline = _pipelineBuilder
+        .UseDefaultHistory()
+        .UseOrchestrator()
+        .Use(new LoadPluginsStep())
+        .UseTaskRunner()
+        .Use(new SaveOutputStep())
+        .Build();
+
+    await pipeline.RunAsync(context);
+    return Ok(new AgentResponse { Result = context.FinalResult ?? string.Empty });
+}
+```
+
+Steps can easily be swapped or removed. Additional pipelines might include alternate plugin selectors, additional pre/post-processing or specialised agent types.
+
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,80 @@
+# Agent Pipeline Refactor Roadmap
+
+This document outlines the high level plan for restructuring how agent requests are processed. The goal is to simplify the `AgentRunner` layer, encourage composition over inheritance and make it easy to build pipelines with only the steps required for a given task.
+
+## Motivation
+- `SleeprAgentRunner` currently orchestrates history parsing, tool selection, plugin loading, agent invocation and output persistence. All responsibilities are tightly coupled and hard to extend.
+- New integrations tend to add more code inside runner classes, increasing complexity.
+- We want controllers to compose pipelines from small building blocks and to reuse those blocks across different agent types.
+
+## Design Goals
+1. **Composable steps** – each operation (loading prompts, selecting plugins, running an agent, saving output, etc.) becomes a standalone step that implements a common interface.
+2. **Fluent builder API** – pipelines are assembled using a fluent style allowing steps to be reused or replaced.
+3. **Kernel cloning with plugin subsets** – keep the current behaviour where only a subset of plugins is added to a cloned kernel. Selection logic lives in a dedicated step.
+4. **No inheritance requirements** – steps are plain classes implementing a single interface. Pipelines rely on composition of these steps.
+5. **Ease of extension** – new behaviours can be introduced by writing additional steps or decorators without changing existing ones.
+
+## Current State Summary
+- Requests hit `AgentController` or `ChatCompletionsController`.
+- `IAgentRunner` and `IChatCompletionsRunner` perform all orchestration internally.
+- `SleeprAgentFactory` clones the kernel and injects plugins based on names returned from the orchestrator.
+- Plugin discovery and acquisition live in `McpPluginManager`.
+
+While functional, this design makes it difficult to reuse parts of the flow (for example running the orchestrator alone, or injecting plugins for a different type of agent). Error handling and logging are spread across the runners.
+
+## Proposed Architecture
+### Core Concepts
+- **PipelineContext** – a data object passed between steps containing the request history, kernel, plugin manager and arbitrary metadata (selected plugin names, final result, etc.).
+- **IAgentPipelineStep** – interface with a single method:
+  ```csharp
+  Task ExecuteAsync(PipelineContext context);
+  ```
+  Each step reads and modifies the context as needed.
+- **AgentPipeline** – executes a list of `IAgentPipelineStep` instances sequentially.
+- **AgentPipelineBuilder** – fluent API for constructing pipelines. Example:
+  ```csharp
+  var pipeline = new AgentPipelineBuilder()
+      .Use(new LoadChatHistoryStep())
+      .Use(new SelectPluginsStep())
+      .Use(new LoadPluginsStep())
+      .Use(new RunTaskAgentStep("task-runner"))
+      .Use(new SaveOutputStep())
+      .Build();
+  ```
+
+### Example Steps
+- **LoadChatHistoryStep** – converts `AgentRequest` into `ChatHistory`/`AgentThread` structures.
+- **SelectPluginsStep** – runs the orchestrator agent or other logic to decide which plugins to add. It populates `context.SelectedPlugins`.
+- **LoadPluginsStep** – clones `context.Kernel` and adds only the plugins from `context.SelectedPlugins` using `McpPluginManager`.
+- **RunTaskAgentStep** – executes a task agent using the cloned kernel.
+- **SaveOutputStep** – persists the final response using an `IAgentOutput` implementation.
+
+Steps can be replaced or extended. For instance, a custom step may log telemetry, validate output or branch to multiple agents.
+
+### Controller Interaction
+Controllers request an `IAgentPipelineBuilder` from DI, configure it and execute the resulting pipeline:
+```csharp
+var pipeline = pipelineBuilder
+    .UseDefaultHistory()
+    .UseOrchestrator()
+    .UseTaskRunner()
+    .Build();
+var response = await pipeline.RunAsync(new PipelineContext(history));
+```
+`UseOrchestrator` and `UseTaskRunner` are extension methods that register standard steps.
+
+### Retaining Plugin Subset Behaviour
+`LoadPluginsStep` will clone the kernel (`context.Kernel.Clone()`) and only add plugins whose names appear in `context.SelectedPlugins`. The orchestration logic that decides these names is contained in `SelectPluginsStep` which could rely on an orchestrator agent or any other mechanism.
+
+## Migration Plan
+1. **Introduce core abstractions** (`PipelineContext`, `IAgentPipelineStep`, `AgentPipeline`, `AgentPipelineBuilder`).
+2. **Refactor existing logic** from `SleeprAgentRunner` into the step classes listed above.
+3. **Create extension methods** to easily register common pipelines (e.g. `builder.UseStandardAgent()`).
+4. **Update controllers** to build and run pipelines using the builder instead of calling runners directly.
+5. **Deprecate old runners** once the new pipeline is fully validated.
+
+## Next Steps
+- Draft the exact interfaces and builder API (see `PIPELINE_API.md`).
+- Incrementally move functionality from existing runners into pipeline steps.
+- Provide unit tests for each step to ensure behaviour parity with the current implementation.
+


### PR DESCRIPTION
## Summary
- add a roadmap describing the planned agent pipeline refactor
- document a fluent pipeline API and usage examples

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687114e58de0832887db4c86c2090bb0