### PR TITLE
Refactor chat completions runner to pipeline steps

### DIFF
--- a/Pipeline/PipelineContext.cs
+++ b/Pipeline/PipelineContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Sleepr.Controllers;
 using Sleepr.Services;
 
@@ -13,7 +14,9 @@ public class PipelineContext
     public Kernel Kernel { get; set; }
     public McpPluginManager PluginManager { get; }
     public IList<string> SelectedPlugins { get; set; } = new List<string>();
+    public ChatHistory? ChatHistory { get; set; }
     public string? FinalResult { get; set; }
+    public string? FilePath { get; set; }
 
     public PipelineContext(
         List<AgentRequestItem> history,

--- a/Pipeline/Steps/LoadChatHistoryStep.cs
+++ b/Pipeline/Steps/LoadChatHistoryStep.cs
@@ -1,0 +1,16 @@
+using Sleepr.Agents;
+using Sleepr.Pipeline.Interfaces;
+
+namespace Sleepr.Pipeline.Steps;
+
+/// <summary>
+/// Converts the request history into a ChatHistory instance.
+/// </summary>
+public class LoadChatHistoryStep : IAgentPipelineStep
+{
+    public Task ExecuteAsync(PipelineContext context)
+    {
+        context.ChatHistory = ChatHistoryBuilder.FromChatRequest(context.RequestHistory);
+        return Task.CompletedTask;
+    }
+}

--- a/Pipeline/Steps/RunChatCompletionStep.cs
+++ b/Pipeline/Steps/RunChatCompletionStep.cs
@@ -1,0 +1,24 @@
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Sleepr.Pipeline.Interfaces;
+
+namespace Sleepr.Pipeline.Steps;
+
+/// <summary>
+/// Runs the chat completion service using the built chat history.
+/// </summary>
+public class RunChatCompletionStep : IAgentPipelineStep
+{
+    public async Task ExecuteAsync(PipelineContext context)
+    {
+        if (context.ChatHistory == null)
+        {
+            return;
+        }
+
+        var chatService = context.Kernel.GetRequiredService<IChatCompletionService>();
+        var result = await chatService.GetChatMessageContentAsync(context.ChatHistory);
+
+        context.FinalResult = result.Content ?? result.ToString();
+    }
+}

--- a/Pipeline/Steps/SaveOutputStep.cs
+++ b/Pipeline/Steps/SaveOutputStep.cs
@@ -1,0 +1,27 @@
+using Sleepr.Interfaces;
+using Sleepr.Pipeline.Interfaces;
+
+namespace Sleepr.Pipeline.Steps;
+
+/// <summary>
+/// Persists the final result using an IAgentOutput implementation.
+/// </summary>
+public class SaveOutputStep : IAgentPipelineStep
+{
+    private readonly IAgentOutput _output;
+
+    public SaveOutputStep(IAgentOutput output)
+    {
+        _output = output;
+    }
+
+    public async Task ExecuteAsync(PipelineContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.FinalResult))
+        {
+            return;
+        }
+
+        context.FilePath = await _output.SaveAsync(context.FinalResult);
+    }
+}


### PR DESCRIPTION
## Summary
- add support properties to `PipelineContext`
- introduce `LoadChatHistoryStep`, `RunChatCompletionStep` and `SaveOutputStep`
- refactor `ChatCompletionsRunner` to run a pipeline built from the new steps

## Testing
- `dotnet build -nologo`

------
https://chatgpt.com/codex/tasks/task_e_68718662aaf08328ac1ec49033aa541a