### PR TITLE
Manage agents in pipeline

### DIFF
--- a/Agents/ChatCompletionsRunner.cs
+++ b/Agents/ChatCompletionsRunner.cs
@@ -28,6 +28,7 @@ public class ChatCompletionsRunner : IChatCompletionsRunner
             .Use(new LoadChatHistoryStep())
             .Use(new RunChatCompletionStep())
             .Use(new SaveOutputStep(_outputManager))
+            .Use(new CleanupAgentsStep())
             .Build();
 
         var context = _contextFactory.Create(history);

--- a/Pipeline/AgentContext.cs
+++ b/Pipeline/AgentContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.SemanticKernel.Agents;
+
+namespace Sleepr.Pipeline;
+
+/// <summary>
+/// Holds a created agent instance along with metadata needed for cleanup.
+/// </summary>
+public class AgentContext
+{
+    public ChatCompletionAgent Agent { get; }
+    public IList<string> PluginIds { get; }
+
+    public AgentContext(ChatCompletionAgent agent, IList<string>? pluginIds = null)
+    {
+        Agent = agent;
+        PluginIds = pluginIds ?? new List<string>();
+    }
+}

--- a/Pipeline/PipelineContext.cs
+++ b/Pipeline/PipelineContext.cs
@@ -17,6 +17,8 @@ public class PipelineContext
     public ChatHistory? ChatHistory { get; set; }
     public string? FinalResult { get; set; }
     public string? FilePath { get; set; }
+    // Holds agents created during the pipeline so they can be disposed/cleaned up later
+    public Dictionary<string, AgentContext> Agents { get; } = new();
 
     public PipelineContext(
         List<AgentRequestItem> history,

--- a/Pipeline/Steps/CleanupAgentsStep.cs
+++ b/Pipeline/Steps/CleanupAgentsStep.cs
@@ -1,0 +1,22 @@
+using Sleepr.Pipeline.Interfaces;
+
+namespace Sleepr.Pipeline.Steps;
+
+/// <summary>
+/// Disposes any agents stored in the PipelineContext and releases their plugin clients.
+/// </summary>
+public class CleanupAgentsStep : IAgentPipelineStep
+{
+    public async Task ExecuteAsync(PipelineContext context)
+    {
+        foreach (var kvp in context.Agents)
+        {
+            // Release any plugin clients acquired for this agent
+            foreach (var id in kvp.Value.PluginIds)
+            {
+                await context.PluginManager.ReleaseClientAsync(id);
+            }
+        }
+        context.Agents.Clear();
+    }
+}


### PR DESCRIPTION
## Summary
- extend `PipelineContext` with dictionary of `AgentContext`
- create `AgentContext` class to hold agent info
- add `CleanupAgentsStep` to release MCP clients
- run `CleanupAgentsStep` at end of `ChatCompletionsRunner` pipeline

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687625c42ec483288b1b347ef3dc2a78