### PR TITLE
Convert SleeprAgentRunner to fluent pipeline

### DIFF
--- a/Agents/SleeprAgentRunner.cs
+++ b/Agents/SleeprAgentRunner.cs
@@ -1,142 +1,46 @@
-﻿using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.Agents;
-using Microsoft.SemanticKernel.ChatCompletion;
 using Sleepr.Controllers;
 using Sleepr.Interfaces;
-using Sleepr.Services;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-
+using Sleepr.Pipeline;
+using Sleepr.Pipeline.Interfaces;
+using Sleepr.Pipeline.Steps;
 
 namespace Sleepr.Agents;
-
-public class ToolsResponse
-{
-    public List<string> Tools { get; set; }
-}
 
 public class SleeprAgentRunner : IAgentRunner
 {
     private readonly ILogger<SleeprAgentRunner> _logger;
     private readonly ISleeprAgentFactory _factory;
-    private readonly McpPluginManager _pluginManager;
+    private readonly IPipelineContextFactory _contextFactory;
     private readonly IAgentOutput _outputManager;
 
     public SleeprAgentRunner(
         ILogger<SleeprAgentRunner> logger,
         ISleeprAgentFactory factory,
-        McpPluginManager pluginManager,
+        IPipelineContextFactory contextFactory,
         IAgentOutput outputManager)
     {
         _logger = logger;
         _factory = factory;
-        _pluginManager = pluginManager;
+        _contextFactory = contextFactory;
         _outputManager = outputManager;
     }
 
     public async Task<AgentResponse> RunTaskAsync(List<AgentRequestItem> history)
     {
-        var (user_message, thread) = ChatHistoryBuilder.FromAgentRequest(history);
-        var orchestrator = await _factory.CreateOrchestratorAgentAsync(path: "orchestrator");
+        var pipeline = new AgentPipelineBuilder()
+            .Use(new OrchestratePluginsStep(_factory))
+            .Use(new RunTaskAgentStep(_factory))
+            .Use(new SaveOutputStep(_outputManager))
+            .Use(new CleanupAgentsStep())
+            .Build();
 
-        //var toolsDict = new Dictionary<string, string>
-        //{
-        //    ["Weather"] = "Get weather forecasts based on location",
-        //    ["Email"] = "Use FastMail API to retrieve, send and read emails",
-        //    ["Maps"] = "Use Google Maps API to retrieve map data"
-        //};
-        var toolsDict = _pluginManager.ListAvailableServers()
-            .ToDictionary(m => m.Name, m => m.Description);
+        var context = _contextFactory.Create(history);
+        await pipeline.RunAsync(context);
 
-        string toolsList = string.Join("\n", toolsDict
-           .Select(kv => $"- **{kv.Key}**: {kv.Value}"));
-
-        _logger.LogInformation("Tools list: {ToolsList}", toolsList);
-        var args = new KernelArguments
+        return new AgentResponse
         {
-            ["tools_list"] = toolsList
+            Result = context.FinalResult ?? string.Empty,
+            FilePath = context.FilePath
         };
-    
-        List<string> pluginNames = new List<string>();
-        await foreach (ChatMessageContent message in orchestrator.InvokeAsync(user_message, thread, new AgentInvokeOptions { KernelArguments = args }))
-        {
-            if (message.Role == AuthorRole.Assistant)
-            {
-                // Process the assistant's response
-                pluginNames = GetToolsFromJsonResponse(message.Content!);
-                _logger.LogInformation("Received assistant message: {MessageContent}. PluginNames: {PluginCount}", message.Content, pluginNames.Count);
-            }
-            else if (message.Role == AuthorRole.Tool)
-            {
-                // Process the user's response
-                _logger.LogWarning("Tool call attempted in orchestrator: {MessageContent}", message.Content);
-            }
-            else
-            {
-                // Handle other roles if necessary
-                _logger.LogInformation("Received message from {Role}: {Content}", message.Role, message.Content);
-            }
-        }
-
-        var taskAgent = await _factory.CreateTaskAgentAsync(path: "task-runner", pluginNames);
-        var taskThread = new ChatHistoryAgentThread();
-        string agentFinalResponse = string.Empty;
-        await foreach (ChatMessageContent message in taskAgent.InvokeAsync(user_message, taskThread, new AgentInvokeOptions { KernelArguments = args }))
-        {
-            if (message.Role == AuthorRole.Assistant)
-            {
-                // Process the assistant's response
-                agentFinalResponse = message.Content ?? string.Empty;
-            }
-            else if (message.Role == AuthorRole.Tool)
-            {
-                // Process the user's response
-                Console.WriteLine($"INFO: Tool call made {message.Content}");
-            }
-            else
-            {
-                // Handle other roles if necessary
-                Console.WriteLine($"INFO: Received message from {message.Role}: {message.Content}");
-            }
-        }
-
-        // return new AgentResponse { Result = response.Content, FilePath = path };
-        var path = await _outputManager.SaveAsync(agentFinalResponse);
-        // Console.WriteLine($"Tool list: {GetStringFromToolList(pluginNames)}");
-        _logger.LogInformation("Final agent response: {AgentResponse}", agentFinalResponse);
-        return new AgentResponse { Result = agentFinalResponse, FilePath = "" };
-
-    }
-
-    public List<string> GetToolsFromJsonResponse(string jsonResponse)
-    {
-        var options = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        };
-        try
-        {
-            var firstJson = ExtractFirstJsonObject(jsonResponse);
-            var toolsResponse = JsonSerializer.Deserialize<ToolsResponse>(firstJson, options);
-            var tools = toolsResponse?.Tools;
-            _logger.LogInformation("Extracted tools from orchestrator: {ToolsCount}", tools?.Count ?? 0);
-            return tools ?? new List<string>();
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogError(ex, "Error deserializing JSON response: {JsonResponse}", jsonResponse);
-            return new List<string>();
-        }
-    }
-
-    public string GetStringFromToolList(List<string> tools)
-    {
-        return string.Join(", ", tools);
-    }
-
-    public string ExtractFirstJsonObject(string input)
-    {
-        var m = Regex.Match(input, @"\{[\s\S]*\}");
-        return m.Success ? m.Value : input; // fallback to original if no match
     }
 }

--- a/Pipeline/AgentContext.cs
+++ b/Pipeline/AgentContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Sleepr.Pipeline;
 
@@ -9,6 +10,8 @@ public class AgentContext
 {
     public ChatCompletionAgent Agent { get; }
     public IList<string> PluginIds { get; }
+    public ChatHistoryAgentThread? Thread { get; set; }
+    public string? ToolsList { get; set; }
 
     public AgentContext(ChatCompletionAgent agent, IList<string>? pluginIds = null)
     {

--- a/Pipeline/PipelineContext.cs
+++ b/Pipeline/PipelineContext.cs
@@ -15,6 +15,7 @@ public class PipelineContext
     public McpPluginManager PluginManager { get; }
     public IList<string> SelectedPlugins { get; set; } = new List<string>();
     public ChatHistory? ChatHistory { get; set; }
+    public string? UserMessage { get; set; }
     public string? FinalResult { get; set; }
     public string? FilePath { get; set; }
     // Holds agents created during the pipeline so they can be disposed/cleaned up later

--- a/Pipeline/Steps/OrchestratePluginsStep.cs
+++ b/Pipeline/Steps/OrchestratePluginsStep.cs
@@ -1,0 +1,49 @@
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Sleepr.Agents;
+using Sleepr.Interfaces;
+using Sleepr.Pipeline.Interfaces;
+using Sleepr.Pipeline;
+using Sleepr.Pipeline.Utils;
+using Sleepr.Services;
+
+namespace Sleepr.Pipeline.Steps;
+
+public class OrchestratePluginsStep : IAgentPipelineStep
+{
+    private readonly ISleeprAgentFactory _factory;
+    private readonly string _path;
+
+    public OrchestratePluginsStep(ISleeprAgentFactory factory, string path = "orchestrator")
+    {
+        _factory = factory;
+        _path = path;
+    }
+
+    public async Task ExecuteAsync(PipelineContext context)
+    {
+        var (userMessage, thread) = ChatHistoryBuilder.FromAgentRequest(context.RequestHistory);
+        context.UserMessage = userMessage;
+
+        var toolsList = PluginUtils.BuildToolsList(context.PluginManager);
+        var args = new KernelArguments { ["tools_list"] = toolsList };
+
+        var orchestrator = await _factory.CreateOrchestratorAgentAsync(_path);
+        context.Agents["orchestrator"] = new AgentContext(orchestrator)
+        {
+            Thread = thread,
+            ToolsList = toolsList
+        };
+
+        var pluginNames = new List<string>();
+        await foreach (ChatMessageContent message in orchestrator.InvokeAsync(userMessage, thread, new AgentInvokeOptions { KernelArguments = args }))
+        {
+            if (message.Role == AuthorRole.Assistant)
+            {
+                pluginNames = PluginUtils.GetToolsFromJsonResponse(message.Content ?? string.Empty);
+            }
+        }
+        context.SelectedPlugins = pluginNames;
+    }
+}

--- a/Pipeline/Steps/RunTaskAgentStep.cs
+++ b/Pipeline/Steps/RunTaskAgentStep.cs
@@ -1,0 +1,58 @@
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Sleepr.Interfaces;
+using Sleepr.Pipeline.Interfaces;
+using Sleepr.Pipeline;
+using System.Linq;
+
+namespace Sleepr.Pipeline.Steps;
+
+public class RunTaskAgentStep : IAgentPipelineStep
+{
+    private readonly ISleeprAgentFactory _factory;
+    private readonly string _path;
+
+    public RunTaskAgentStep(ISleeprAgentFactory factory, string path = "task-runner")
+    {
+        _factory = factory;
+        _path = path;
+    }
+
+    public async Task ExecuteAsync(PipelineContext context)
+    {
+        var pluginNames = context.SelectedPlugins.ToList();
+        var agent = await _factory.CreateTaskAgentAsync(_path, pluginNames);
+
+        var pluginIds = pluginNames
+            .Select(name => context.PluginManager.GetManifestByName(name).Id)
+            .ToList();
+
+        var toolsList = context.Agents.TryGetValue("orchestrator", out var orchestrator)
+            ? orchestrator.ToolsList
+            : null;
+        var thread = new ChatHistoryAgentThread();
+        context.Agents["task-agent"] = new AgentContext(agent, pluginIds)
+        {
+            Thread = thread,
+            ToolsList = toolsList
+        };
+
+        var args = new KernelArguments();
+        if (!string.IsNullOrWhiteSpace(toolsList))
+        {
+            args["tools_list"] = toolsList;
+        }
+        string finalResponse = string.Empty;
+
+        await foreach (ChatMessageContent message in agent.InvokeAsync(context.UserMessage ?? string.Empty, thread, new AgentInvokeOptions { KernelArguments = args }))
+        {
+            if (message.Role == AuthorRole.Assistant)
+            {
+                finalResponse = message.Content ?? string.Empty;
+            }
+        }
+
+        context.FinalResult = finalResponse;
+    }
+}

--- a/Pipeline/Utils/PluginUtils.cs
+++ b/Pipeline/Utils/PluginUtils.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Sleepr.Services;
+
+namespace Sleepr.Pipeline.Utils;
+
+/// <summary>
+/// Utility methods for orchestrating and running plugin agents.
+/// </summary>
+public static class PluginUtils
+{
+    public static string BuildToolsList(McpPluginManager pluginManager)
+    {
+        var dict = pluginManager.ListAvailableServers()
+            .ToDictionary(m => m.Name, m => m.Description);
+        return string.Join("\n", dict.Select(kv => $"- **{kv.Key}**: {kv.Value}"));
+    }
+
+    public static List<string> GetToolsFromJsonResponse(string jsonResponse)
+    {
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        try
+        {
+            var first = ExtractFirstJsonObject(jsonResponse);
+            var toolsResponse = JsonSerializer.Deserialize<ToolsResponse>(first, options);
+            return toolsResponse?.Tools ?? new List<string>();
+        }
+        catch (JsonException)
+        {
+            return new List<string>();
+        }
+    }
+
+    private static string ExtractFirstJsonObject(string input)
+    {
+        var m = Regex.Match(input, "{[\\s\\S]*}");
+        return m.Success ? m.Value : input;
+    }
+
+    private class ToolsResponse
+    {
+        public List<string> Tools { get; set; } = new();
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite `SleeprAgentRunner` to build and run a fluent pipeline
- store agents via `PipelineContext` and release them with `CleanupAgentsStep`
- create `OrchestratePluginsStep` and `RunTaskAgentStep`
- extend `PipelineContext` with fields for user message, thread and tools list
- extract helper methods into `PluginUtils` and move agent state into `AgentContext`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68762a24df1c8328a00c1d3e71712b6f