### PR TITLE
Track plugin ids with AgentContext

### DIFF
--- a/Interfaces/ISleeprAgentFactory.cs
+++ b/Interfaces/ISleeprAgentFactory.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.SemanticKernel.Agents;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Sleepr.Pipeline;
 
 namespace Sleepr.Interfaces;
 
 public interface ISleeprAgentFactory
 {
-    Task<ChatCompletionAgent> CreateOrchestratorAgentAsync(string path);
-    Task<ChatCompletionAgent> CreateTaskAgentAsync(string path, List<string> selectedPlugins);
+    Task<AgentContext> CreateOrchestratorAgentAsync(string path);
+    Task<AgentContext> CreateTaskAgentAsync(string path, List<string> selectedPlugins);
 }

--- a/Pipeline/Steps/OrchestratePluginsStep.cs
+++ b/Pipeline/Steps/OrchestratePluginsStep.cs
@@ -29,15 +29,13 @@ public class OrchestratePluginsStep : IAgentPipelineStep
         var toolsList = PluginUtils.BuildToolsList(context.PluginManager);
         var args = new KernelArguments { ["tools_list"] = toolsList };
 
-        var orchestrator = await _factory.CreateOrchestratorAgentAsync(_path);
-        context.Agents["orchestrator"] = new AgentContext(orchestrator)
-        {
-            Thread = thread,
-            ToolsList = toolsList
-        };
+        var orchestratorCtx = await _factory.CreateOrchestratorAgentAsync(_path);
+        orchestratorCtx.Thread = thread;
+        orchestratorCtx.ToolsList = toolsList;
+        context.Agents["orchestrator"] = orchestratorCtx;
 
         var pluginNames = new List<string>();
-        await foreach (ChatMessageContent message in orchestrator.InvokeAsync(userMessage, thread, new AgentInvokeOptions { KernelArguments = args }))
+        await foreach (ChatMessageContent message in orchestratorCtx.Agent.InvokeAsync(userMessage, thread, new AgentInvokeOptions { KernelArguments = args }))
         {
             if (message.Role == AuthorRole.Assistant)
             {


### PR DESCRIPTION
## Summary
- use `AgentContext` as the return type from `ISleeprAgentFactory`
- embed plugin ids in the factory when building agents
- adjust `OrchestratePluginsStep` and `RunTaskAgentStep` for the new API

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687637295f688328ada61fce397075dc